### PR TITLE
fix: Use `original` image size for `og:image`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-open-graph",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Facebook's Open Graph for ApostropheCMS",
   "main": "index.js",
   "scripts": {

--- a/views/view.html
+++ b/views/view.html
@@ -18,7 +18,7 @@
 {% if context.openGraphImage %}
   {% if apos.images.first(context.openGraphImage) %}
     {% set openGraphImageObj = apos.images.first(context.openGraphImage) %}
-    {% set openGraphImagePath = apos.attachments.url(openGraphImageObj, { size: 'full' })  %}
+    {% set openGraphImagePath = apos.attachments.url(openGraphImageObj, { size: 'original' })  %}
   {% endif %}
 {% endif %}
 <meta property="og:url" content="{{ openGraphUrl }}" />


### PR DESCRIPTION
Closes #17

I thought about adding an option to the extension which would allow the user to set a specific size. But I like the simplicity of the module and if need be the user could always override the `view.html` in his/her project.

Setting the size to `original` seems right to me as the user previously chose an image with appropriate dimensions (1200px wide) as defined in the plugin field settings. Outputting a path to an image with smaller dimensions feels like a bug to me.

What do you think?

Thanks for considering the PR! 